### PR TITLE
Switch from Travis CI to a GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Retreon CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run:
+        - yarn install
+        - ./run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-- 10
-- 12
-
-script: ./run-tests


### PR DESCRIPTION
I hate doing this. I hate it with a passion. Microsoft doesn't need more
market share on developer tools, but they've been bullying Travis CI and
continuously breaking their integrations, rate limiting them, and hiding
their results on the PR tab. I want to fight this, but I've only got so
much bandwidth. I don't have the time to figure out how to integrate
another CI system. Without the integration, I can't trust any changes or
automatic upgrades. It's making my personal projects unmaintainable.

I'm giving up and buying in. I'm so disgusted with myself right now.