### PR TITLE
Remove error reducer type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ createReducer(initialState, handleAction => [
   }),
 
   // The payload is whatever you passed to `failure(...)`.
-  handleAction.error(settings.save, (state, payload) => {
+  handleAction.error(settings.save, (state, error) => {
     // Only handles failure.
   }),
 ])

--- a/src/actions/__tests__/create-action.test.ts
+++ b/src/actions/__tests__/create-action.test.ts
@@ -86,30 +86,6 @@ describe('createAction', () => {
       expectType<string>(action.payload);
     });
 
-    it('infers error types from effect return types', () => {
-      const fail = createAction('failure', () => failure(1337));
-      const action = fail();
-
-      expectType<number>(action.payload);
-      expectType<{ error: true }>(action);
-    });
-
-    it('infers union types for possible failures', () => {
-      const mixed = createAction('mixed-result', () => {
-        if (Math.random() >= 0.5) return failure(1);
-        return 'or a string';
-      });
-
-      const args: Parameters<typeof mixed> = [];
-      const action = mixed(...args);
-
-      if (action.error === true) {
-        expectType<number>(action.payload);
-      } else {
-        expectType<string>(action.payload);
-      }
-    });
-
     it('infers required argument types', () => {
       const requiredArg = createAction('type', (value: string) => value);
 

--- a/src/types/create-reducer.ts
+++ b/src/types/create-reducer.ts
@@ -72,10 +72,7 @@ interface HandleAction<State> {
    */
   error<
     ActionCreator extends (...args: any) => any,
-    Reducer extends (
-      state: Draft<State>,
-      action: FailurePayload<ActionCreator>,
-    ) => NextState<State>
+    Reducer extends (state: Draft<State>, error: unknown) => NextState<State>
   >(
     actionCreator: ActionCreator,
     reducer: Reducer,
@@ -125,16 +122,6 @@ export type SuccessPayload<
   ? Payload
   : ReduxAction<ActionCreator> extends ActionSuccess<infer Payload>
   ? Payload
-  : never;
-
-export type FailurePayload<
-  ActionCreator extends (...args: any) => any
-> = ReduxAction<ActionCreator> extends
-  | ActionSuccess<any>
-  | ActionFailure<infer Failure>
-  ? Failure
-  : ReduxAction<ActionCreator> extends ActionFailure<infer Failure>
-  ? Failure
   : never;
 
 export type OptimisticPayload<


### PR DESCRIPTION
I'm removing the `failure(...)` return value and replacing it with
a bulk catch for thrown errors, which means the error type is no longer
inferable for `handleAction.error(...)`. It will become `unknown`. I'll
encourage custom errors and instance checks instead.

Closes #204