### PR TITLE
Report synchronous action errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ a Changelog](https://keepachangelog.com/en/1.0.0/) and the project adheres to
 [semver](https://semver.org/).
 
 ## [UNRELEASED]
+Added:
+- Error handling for every error thrown in an action, not just `failure(...)`
+  return values.
+- Support for dispatching synchronous iterators. This is an advanced and
+  rarely useful feature.
+
+Removed:
+- Payload type inference in `handleAction.error(...)` (`throw` types aren't
+  statically analyzable).
+
+Changed:
+- All action creators return iterators now. This may break your tests.
 
 ## [0.2.0] - 2020-06-20
 Changed:

--- a/src/actions/__tests__/create-action.test.ts
+++ b/src/actions/__tests__/create-action.test.ts
@@ -1,5 +1,4 @@
 import createAction from '../create-action';
-import { failure } from '../failure';
 import { expectType, expectNotType } from '../../types/assertions';
 import Phase from '../../constants/phase';
 import {
@@ -11,13 +10,17 @@ import {
   isActionSuccess,
   isOptimisticAction,
 } from '../../utils/action-variant';
+import { mixin } from '../../utils/errors';
 
 describe('createAction', () => {
   it('returns an action creator', () => {
     const doTheThing = createAction('the-thing', () => 'payload');
 
     expect(doTheThing).toEqual(expect.any(Function));
-    expect(doTheThing()).toEqual({ type: 'the-thing', payload: 'payload' });
+
+    expect(Array.from(doTheThing())).toEqual([
+      { type: 'the-thing', payload: 'payload' },
+    ]);
   });
 
   it('coerces to the action type', () => {
@@ -32,14 +35,51 @@ describe('createAction', () => {
     expect(fail).toThrow(/action.type/i);
   });
 
-  it('returns an error type if given a failure', () => {
-    const doTheThing = createAction('effect', () => failure('nope'));
+  it('yields an error type if the effect throws', () => {
+    class KnownError extends mixin(Error) {}
+    const error = new KnownError('testing known effect errors');
 
-    expect(doTheThing()).toEqual({
+    const doTheThing = createAction('effect', () => {
+      throw error;
+    });
+
+    expect(Array.from(doTheThing())).toEqual([
+      {
+        type: 'effect',
+        error: true,
+        payload: error,
+      },
+    ]);
+  });
+
+  it('returns the error type for recognized errors', () => {
+    class KnownError extends mixin(Error) {}
+    const error = new KnownError('testing known effect errors');
+
+    const doTheThing = createAction('effect', () => {
+      throw error;
+    });
+
+    const iterator = doTheThing();
+
+    // First yield is the action, last is the return value.
+    expect(iterator.next().value).toEqual(iterator.next().value);
+  });
+
+  it('re-throws unrecognized errors', () => {
+    const error = new Error('testing unknown effect errors');
+    const doTheThing = createAction('effect', () => {
+      throw error;
+    });
+
+    const iterator = doTheThing();
+    expect(iterator.next().value).toEqual({
       type: 'effect',
       error: true,
-      payload: 'nope',
+      payload: error,
     });
+
+    expect(() => iterator.next()).toThrow(error);
   });
 
   // Other parameters reserved for future use. Pass an object instead.
@@ -47,14 +87,14 @@ describe('createAction', () => {
     const effect = jest.fn();
     const increment = createAction('increment', effect);
 
-    (increment as any)(1, null);
+    Array.from((increment as any)(1, null));
 
     expect(effect).toHaveBeenCalledWith(1);
   });
 
   it('uses an undefined payload if no effect is provided', () => {
     const increment = createAction('increment');
-    const action = increment();
+    const [action] = Array.from(increment());
 
     expectType<VoidAction>(action);
     expect(action).toEqual({
@@ -65,7 +105,7 @@ describe('createAction', () => {
   it('uses the argument as payload when no effect was provided', () => {
     const increment = createAction<string>('action-type');
     const args: Parameters<typeof increment> = ['some content'];
-    const action = increment(...args);
+    const [action] = Array.from(increment(...args));
 
     expectType<string>(action.payload);
     expect(action.payload).toBe(args[0]);
@@ -74,32 +114,42 @@ describe('createAction', () => {
   describe('type', () => {
     it('infers that payloads are missing in void actions', () => {
       const increment = createAction('increment');
-      const action = increment();
+      const [action] = Array.from(increment());
 
       expectNotType<{ payload: any }, typeof action>(action);
     });
 
     it('infers the payload type returned from effects', () => {
       const simple = createAction('simple', () => 'content');
-      const action = simple();
+      const [action] = Array.from(simple());
 
-      expectType<string>(action.payload);
+      if (action.error === true) {
+        expectType<unknown>(action.payload);
+      } else {
+        expectType<string>(action.payload);
+      }
     });
 
     it('infers required argument types', () => {
       const requiredArg = createAction('type', (value: string) => value);
 
       const args: Parameters<typeof requiredArg> = ['hello world'];
-      const action = requiredArg(...args);
-      expectType<string>(action.payload);
+      const [action] = Array.from(requiredArg(...args));
+
+      if (action.error !== true) {
+        expectType<string>(action.payload);
+      }
     });
 
     it('only exposes one parameter from the effect', () => {
       const requiredArg = createAction('type', (_: string, n: number) => n);
 
       const args: Parameters<typeof requiredArg> = ['hello world'];
-      const action = requiredArg(...args);
-      expectType<number>(action.payload);
+      const [action] = Array.from(requiredArg(...args));
+
+      if (action.error !== true) {
+        expectType<number>(action.payload);
+      }
     });
   });
 

--- a/src/examples/counter/__tests__/reducer.test.ts
+++ b/src/examples/counter/__tests__/reducer.test.ts
@@ -1,20 +1,29 @@
+import { createStore, applyMiddleware } from 'redux';
+
 import reducer from '../reducer';
 import * as counter from '../actions';
+import { middleware } from '../../../index';
 
 describe('Counter reducer', () => {
+  const setup = () => createStore(reducer, applyMiddleware(middleware));
+
   describe('increment(...)', () => {
     it('increments the count', () => {
-      const state = reducer(5, counter.increment());
+      const store = setup();
 
-      expect(state).toBe(6);
+      expect(store.getState()).toBe(0);
+      store.dispatch(counter.increment());
+      expect(store.getState()).toBe(1);
     });
   });
 
   describe('decrement(...)', () => {
     it('decrements the count', () => {
-      const state = reducer(5, counter.decrement());
+      const store = setup();
 
-      expect(state).toBe(4);
+      expect(store.getState()).toBe(0);
+      store.dispatch(counter.decrement());
+      expect(store.getState()).toBe(-1);
     });
   });
 });

--- a/src/types/create-action.ts
+++ b/src/types/create-action.ts
@@ -5,7 +5,6 @@ import {
   ActionFailure,
   VoidAction,
 } from './actions';
-import { Exception } from '../actions/failure';
 import { CreateAsyncAction } from './create-async-action';
 
 type AnyFunction = (...args: any) => any;
@@ -21,36 +20,32 @@ export interface CreateAction extends CreateAsyncAction {
    *   return localStorage.getItem('theme')
    * })
    */
-  (type: ActionConstant): CoercibleAction<[], VoidAction>;
+  (type: ActionConstant): CoercibleAction<[], ActionIterator<VoidAction>>;
 
   // No effect. Just pass a payload.
-  <T>(type: ActionConstant): CoercibleAction<[T], ActionSuccess<T>>;
+  <Payload>(type: ActionConstant): CoercibleAction<
+    [Payload],
+    ActionIterator<ActionSuccess<Payload>>
+  >;
 
   // No arguments.
   <Effect extends () => any>(
     type: ActionConstant,
     effect: Effect,
-  ): CoercibleAction<[], ActionForEffect<Effect>>;
+  ): CoercibleAction<[], ActionOutcomesForEffect<Effect>>;
 
   // At least one argument.
   <Effect extends (arg: any, ...args: any) => any>(
     type: ActionConstant,
     effect: Effect,
   ): Effect extends (arg: infer T, ...args: any) => any
-    ? CoercibleAction<[T], ActionForEffect<Effect>>
+    ? CoercibleAction<[T], ActionOutcomesForEffect<Effect>>
     : never;
 }
 
-type AnythingButException<Value> = Value extends Exception<any> ? never : Value;
+type ActionIterator<Action> = Generator<Action, Action>;
 
-// Turns the return value of an effect into an action object. This is the
-// most difficult type signature of `createAction(...)`. Avoid changing it.
-type ActionForEffect<Effect extends AnyFunction> = ReturnType<
-  Effect
-> extends Exception<infer Failure> // The action always fails.
-  ? ActionFailure<Failure>
-  : ReturnType<Effect> extends AnythingButException<ReturnType<Effect>> // The action never fails.
-  ? ActionSuccess<ReturnType<Effect>>
-  : ReturnType<Effect> extends Exception<infer Failure> | infer Payload // The action *might* fail.
-  ? ActionFailure<Failure> | ActionSuccess<Payload>
-  : never; // The action is drunk.
+// If an effect is provided, we have to assume it can fail.
+type ActionOutcomesForEffect<Effect extends AnyFunction> = ActionIterator<
+  ActionSuccess<ReturnType<Effect>> | ActionFailure<unknown>
+>;


### PR DESCRIPTION
Before this PR, if an error was thrown in an action creator's effect, reducers would have no way of detecting it. While undesirable, it wasn't reasonable to swallow every error.

This PR uses the new generator feature to detect errors, dispatch them as actions, then conditionally re-throw the original error. You get the best of both worlds: reducers always know when something fails, and we still have loud errors in development.

If the error is expected (see "known errors" in [ADR-0001](https://github.com/PsychoLlama/retreon/blob/master/doc/adr/0001-identify-known-errors-through-class-mixins.md)) we can safely swallow the error, preventing false positives and needless noise.

```typescript
import { swallowed, createAction } from 'retreon'

class ApiUnavailableError extends swallowed(Error) {}

export const vibrate = createAction('vibrate', () => {
  if (!navigator.vibrate) {
    throw new ApiUnavailableError('browser not supported')
  }

  navigator.vibrate(100)
})
```