### PR TITLE
Async error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ a Changelog](https://keepachangelog.com/en/1.0.0/) and the project adheres to
 Added:
 - Error handling for every error thrown in an action, not just `failure(...)`
   return values.
+- Error dispatches for async action creators. Just use `throw`.
 - Support for dispatching synchronous iterators. This is an advanced and
   rarely useful feature.
 

--- a/src/actions/create-async-action.ts
+++ b/src/actions/create-async-action.ts
@@ -17,14 +17,25 @@ export default function createAsyncAction<
       meta: { phase: Phase.Optimistic },
     };
 
-    const payload = await effect(input);
+    try {
+      const payload = await effect(input);
 
-    yield {
-      type: actionType,
-      payload,
-    };
+      yield {
+        type: actionType,
+        payload,
+      };
 
-    return payload;
+      return payload;
+    } catch (error) {
+      yield {
+        type: actionType,
+        error: true,
+        payload: error,
+      };
+
+      // TODO: Determine how to treat known errors.
+      throw error;
+    }
   }
 
   return bindActionType(actionType, createAsyncAction);

--- a/src/types/create-async-action.ts
+++ b/src/types/create-async-action.ts
@@ -3,6 +3,7 @@ import {
   CoercibleAction,
   OptimisticAction,
   ActionSuccess,
+  ActionFailure,
 } from './actions';
 
 export interface CreateAsyncAction {
@@ -36,7 +37,9 @@ type AsyncFunction = () => Promise<any>;
 type AnyAsyncFunction = (...args: any) => Promise<any>;
 
 type ActionSequence<Optimistic, TReturn> = AsyncGenerator<
-  OptimisticAction<Optimistic> | ActionSuccess<TReturn>,
+  | OptimisticAction<Optimistic>
+  | ActionSuccess<TReturn>
+  | ActionFailure<unknown>,
   TReturn,
   void
 >;


### PR DESCRIPTION
This PR adds error handling to async action creators closing #205. Just `throw` an error and it'll manifest in an error action.
```ts
createAction.async('fail', async () => {
  await http.get('/bad/url')
  // Happens automatically:
  // dispatch({
  //   type: 'fail',
  //   error: true,
  //   payload: ResponseError,
  // })
})
```